### PR TITLE
i9 - Refactored methods to take URIs instead of strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# VS Code
+.vscode/
+
 # User-specific files
 *.rsuser
 *.suo

--- a/ApiClient.Common/BasicAuthConnection.cs
+++ b/ApiClient.Common/BasicAuthConnection.cs
@@ -45,7 +45,7 @@ namespace ApiClient.Common
 
 			AddBasicAuthenticationHeader(ref headers, username, password);
 
-			string requestUrl = ConnectionConfiguration.BaseRequestUrl + url;
+			var requestUrl = new Uri(ConnectionConfiguration.BaseRequestUrl, url);
 
 			Response response = SendWebRequest(requestUrl, headers);
 
@@ -68,9 +68,9 @@ namespace ApiClient.Common
 
 			AddBasicAuthenticationHeader(ref headers, username, password);
 
-			string requestUrl = ConnectionConfiguration.BaseRequestUrl + url;
+			var requestUrl = new Uri(ConnectionConfiguration.BaseRequestUrl, url);
 
-			Response response = SendWebRequest(requestUrl, headers, body);
+			Response response = SendWebRequest(requestUrl, headers);
 
 			return response;
 		}

--- a/ApiClient.Common/BasicAuthConnectionConfig.cs
+++ b/ApiClient.Common/BasicAuthConnectionConfig.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using ApiClient.Common.Interfaces;
 
 namespace ApiClient.Common
@@ -17,7 +18,7 @@ namespace ApiClient.Common
 		/// <param name="baseRequestUrl">The base request URL for all API requests.</param>
 		/// <param name="responseType">The API response type.</param>
 		/// <param name="requestType">The client request type.</param>
-		public BasicAuthConnectionConfig(string baseRequestUrl, ResponseType responseType, 
+		public BasicAuthConnectionConfig(Uri baseRequestUrl, ResponseType responseType, 
 			RequestType requestType, string username, string password)
 			: base(baseRequestUrl, responseType, requestType)
 		{

--- a/ApiClient.Common/BasicConnection.cs
+++ b/ApiClient.Common/BasicConnection.cs
@@ -73,7 +73,7 @@ namespace ApiClient.Common
 		/// <returns>A <c>Response</c> object.</returns>
 		public virtual Response Get(string url, Dictionary<string, string> headers = null)
 		{
-			string requestUrl = ConnectionConfiguration.BaseRequestUrl + url;
+			var requestUrl = new Uri(ConnectionConfiguration.BaseRequestUrl, url);
 
 			Response response = SendWebRequest(requestUrl, headers);
 
@@ -91,7 +91,7 @@ namespace ApiClient.Common
 		public virtual Response Post(string url, Dictionary<string, string> headers = null, 
 			string body = "")
 		{
-			string requestUrl = ConnectionConfiguration.BaseRequestUrl + url;
+			var requestUrl = new Uri(ConnectionConfiguration.BaseRequestUrl, url);
 
 			Response response = SendWebRequest(requestUrl, headers, body);
 
@@ -136,7 +136,7 @@ namespace ApiClient.Common
 		/// <param name="headers">Custom headers to be sent with the request (optional).</param>
 		/// <param name="body">The request data (optional).</param>
 		/// <returns>A <c>Request</c> object containing the API response.</returns>
-		internal Response SendWebRequest(string url, Dictionary<string, string> headers = null, 
+		internal Response SendWebRequest(Uri url, Dictionary<string, string> headers = null, 
 			string body = "")
 		{
 			HttpResponseMessage response;

--- a/ApiClient.Common/BasicConnectionConfig.cs
+++ b/ApiClient.Common/BasicConnectionConfig.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using ApiClient.Common.Interfaces;
 using ApiClient.Utilities;
 
@@ -18,7 +19,7 @@ namespace ApiClient.Common
 		/// <param name="baseRequestUrl">The base request URL for all API requests.</param>
 		/// <param name="responseType">The API response type.</param>
 		/// <param name="requestType">The client request type.</param>
-		public BasicConnectionConfig(string baseRequestUrl, ResponseType responseType, 
+		public BasicConnectionConfig(Uri baseRequestUrl, ResponseType responseType, 
 			RequestType requestType)
 		{
 			BaseRequestUrl = baseRequestUrl;
@@ -34,7 +35,7 @@ namespace ApiClient.Common
 		/// The base request URL for the API connection.
 		/// </summary>
 		[Required]
-		public string BaseRequestUrl { get; private set; }
+		public Uri BaseRequestUrl { get; private set; }
 
 		/// <summary>
 		/// The <c>ResponseType</c> for all API connection responses. Defaults to application/json.

--- a/ApiClient.Common/Interfaces/IConnectionConfiguration.cs
+++ b/ApiClient.Common/Interfaces/IConnectionConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using ApiClient.Utilities.Interfaces;
 
 namespace ApiClient.Common.Interfaces
@@ -15,7 +16,7 @@ namespace ApiClient.Common.Interfaces
 		/// The base request URL for the API connection.
 		/// </summary>
 		[Required]
-		public string BaseRequestUrl { get; }
+		public Uri BaseRequestUrl { get; }
 
 		/// <summary>
 		/// The <c>ResponseType</c> for all API connection responses.

--- a/ApiClient.SampleApp/Program.cs
+++ b/ApiClient.SampleApp/Program.cs
@@ -9,7 +9,7 @@ namespace ApiClient.SampleApp
 		{
 			Console.WriteLine("Hello World!");
 
-			string url = "https://postman-echo.com";
+			var url = new Uri("https://postman-echo.com");
 			var responseType = ResponseType.PlainText;
 			var requestType = RequestType.Json;
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A `BasicConnection` object is appropriate for an API that does not require any a
 
 	```
 	// Set the URL
-	string url = "https://postman-echo.com"; // The Base URL of the API
+	var url = new Uri("https://postman-echo.com"); // The Base URL of the API
 
 	// Configure your response/request types using the built-in `ResponseType` and `RequestType` 
 	// helpers.


### PR DESCRIPTION
Refactors methods to use `Uri` instead of `string` for URLs.

Fixes #9 