### PR TITLE
[i33] Headers need to be reset after each request

### DIFF
--- a/ApiClient.Common/BasicConnection.cs
+++ b/ApiClient.Common/BasicConnection.cs
@@ -143,12 +143,23 @@ namespace ApiClient.Common
 
 			HttpClient client = GetHttpClient();
 
+			if(client.DefaultRequestHeaders.Contains("Accept"))
+			{
+				client.DefaultRequestHeaders.Remove("Accept");
+			}
+
 			client.DefaultRequestHeaders.Add("Accept", ResponseType);
 
 			if (headers != null)
 			{
 				foreach (var header in headers)
 				{
+					// Avoid adding duplicate headers to our request
+					if(client.DefaultRequestHeaders.Contains(header.Key))
+					{
+						client.DefaultRequestHeaders.Remove(header.Key);
+					}
+
 					client.DefaultRequestHeaders.Add(header.Key, header.Value);
 				}
 			}


### PR DESCRIPTION
This fixes a problem where headers were not being reset after each request, leading to the possibility of duplicate headers in some cases.

Fixes #33